### PR TITLE
[add] レスポンスヘッダにX-Authentication-Tokenを追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,8 @@ module ReservationApp
         origins ENV["CLIENT_HOST"]
         resource "*",
           headers: :any,
-          methods: [:get, :post, :options, :head]
+          methods: [:get, :post, :options, :head],
+          expose: ['X-Authentication-Token']
       end
     end
 


### PR DESCRIPTION
- クライアント側から独自のレスポンスヘッダにアクセスするために必要だったので追加